### PR TITLE
Datadog Fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ VERSION = ${E2E_IMAGE_TAG}
 SUFFIX = -test
 endif
 
+VERSION = 2.17.0-patch
+
 IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPO     ?= kedacore
 
@@ -216,9 +218,9 @@ run: manifests generate ## Run a controller from your host.
 	WATCH_NAMESPACE="" go run -ldflags $(GO_LDFLAGS) ./cmd/operator/main.go $(ARGS)
 
 docker-build: ## Build docker images with the KEDA Operator and Metrics Server.
-	DOCKER_BUILDKIT=1 docker build . -t ${IMAGE_CONTROLLER} --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
-	DOCKER_BUILDKIT=1 docker build -f Dockerfile.adapter -t ${IMAGE_ADAPTER} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
-	DOCKER_BUILDKIT=1 docker build -f Dockerfile.webhooks -t ${IMAGE_WEBHOOKS} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
+	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 . -t ${IMAGE_CONTROLLER} --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
+	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f Dockerfile.adapter -t ${IMAGE_ADAPTER} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
+	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f Dockerfile.webhooks -t ${IMAGE_WEBHOOKS} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
 
 publish: docker-build ## Push images on to Container Registry (default: ghcr.io).
 	docker push $(IMAGE_CONTROLLER)

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"regexp"
 	"slices"
@@ -644,7 +645,10 @@ func (s *datadogScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec
 }
 
 func (s *datadogScaler) fallbackResponse(metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
-	metric := GenerateMetricInMili(metricName, s.metadata.fillValue)
+	// we choose the target value + a small number as the fallback in case the fill value is not set
+	slightlyHigherThanActivationValue := s.metadata.activationQueryValue + math.SmallestNonzeroFloat64
+	fallbackValue := max(s.metadata.fillValue, slightlyHigherThanActivationValue)
+	metric := GenerateMetricInMili(metricName, fallbackValue)
 	return []external_metrics.ExternalMetricValue{metric}, true, nil
 }
 


### PR DESCRIPTION
This is the first PR in the repo so here's the purpose of this repo at the moment (which I'll update the readme with later):
* We're updating our KEDA version to 2.17.0 to address various security vulnerabilities. Because of that the trunk branch, `development` starts off from the offical 2.17 release.
* This PR updates the datadog scalar with KEDA to return `metricUnavailableValue` as the metric value when unable to reach Datadog. The goal is to scale up pods to the max whenever there's a datadog outage. Just in case the unavailable value is below the target value / unspecified, we return a metric value just above the target value to force scaling up
* Added unit tests that pass
* Tested all of this working by deploying the new image in the dev cluster, mocking a datadog outage, and seeing all services scale up

**Note:** We went with a different fix than the one we originally noticed in https://github.com/kedacore/keda/pull/6655. This is because that fix is more complex than the one in this PR, and so doing it this way, we can be more sure of its correctness. The plan is to use the solution in this PR temporarily until https://github.com/kedacore/keda/pull/6655 gets merged. Once that happens, we must:
* Stop using the patch in this PR
* Move to using the [standardized fallback mechanism](https://keda.sh/docs/2.14/concepts/scaling-deployments/#fallback) across all auto scaling configurations