### PR TITLE
No blocking on creation of datadog scaler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VERSION = ${E2E_IMAGE_TAG}
 SUFFIX = -test
 endif
 
-VERSION = 2.17.0-patch
+VERSION = 2.17.0-patch2
 
 IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPO     ?= kedacore


### PR DESCRIPTION
Updating the datadog scaler such that failed API calls still result in fallbacks executing. 

The root of the issue is that the datadog scaler can make external requests on creation. Currently in calls to `NewDatadogScaler()`, a validation endpoint is called to verify a connection can be made. If the endpoint is down, it can result in a failed call to `buildScalers()` [here](https://github.com/kedacore/keda/blob/1d5f3c56a6812cbf387eb24b1bcabae9dee122a8/pkg/scaling/scale_handler.go#L355-L358). Subsequently, calls to `GetScaledObjectMetrics()`, (which can call `buildScalers()` under the hood) then hit [this code block](https://github.com/kedacore/keda/blob/1d5f3c56a6812cbf387eb24b1bcabae9dee122a8/pkg/scaling/scale_handler.go#L428-L433) preventing [the fallback code later in the function](https://github.com/kedacore/keda/blob/1d5f3c56a6812cbf387eb24b1bcabae9dee122a8/pkg/scaling/scale_handler.go#L551) from executing.

This change moves that validation API call into the `GetMetricsAndActivity()` code path which is configured to lead to the fallback path.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
